### PR TITLE
Change type of strings_chain in stringtree_leaf.cpp

### DIFF
--- a/plugins/ros1_introspection/src/stringtree_leaf.cpp
+++ b/plugins/ros1_introspection/src/stringtree_leaf.cpp
@@ -90,7 +90,7 @@ void CreateStringFromTreeLeaf(const StringTreeLeaf& leaf, bool skip_root, std::s
     return;
   }
 
-  boost::container::static_vector<const std::string*, 16> strings_chain;
+  std::vector<const std::string*> strings_chain;
 
   size_t total_size = 0;
 


### PR DESCRIPTION
Changes the type of strings_chain from static_vector to std::vector to support messages with arbitrary depth